### PR TITLE
Upgrade to .NET 6 and function v4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -296,6 +296,7 @@ dotnet_diagnostic.CA1410.severity = warning
 dotnet_diagnostic.CA1415.severity = warning
 dotnet_diagnostic.CA1812.severity = suggestion
 dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.CA1848.severity = suggestion
 dotnet_diagnostic.CA1900.severity = warning
 dotnet_diagnostic.CA1901.severity = warning
 dotnet_diagnostic.CA2002.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -341,6 +341,7 @@ dotnet_diagnostic.CA2238.severity = warning
 dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
+dotnet_diagnostic.CA2254.severity = suggestion
 dotnet_diagnostic.CS1591.severity = none
 
 dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace

--- a/.editorconfig
+++ b/.editorconfig
@@ -269,7 +269,10 @@ csharp_space_between_square_brackets = false
 csharp_preserve_single_line_statements = false
 csharp_preserve_single_line_blocks = true
 
-# Analyzers/StyleCop rules
+###############################
+# .NET Analyzers              #
+###############################
+
 dotnet_diagnostic.CA1303.severity = suggestion
 dotnet_diagnostic.CA1715.severity = error
 dotnet_diagnostic.CA1001.severity = warning
@@ -338,6 +341,15 @@ dotnet_diagnostic.CA2240.severity = warning
 dotnet_diagnostic.CA2241.severity = warning
 dotnet_diagnostic.CA2242.severity = warning
 dotnet_diagnostic.CS1591.severity = none
+
+dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace
+
+###############################
+# StyleCop Analyzers          #
+###############################
+
+# See rules here: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation
+
 dotnet_diagnostic.SA0001.severity = none
 dotnet_diagnostic.SA1000.severity = error
 dotnet_diagnostic.SA1001.severity = error
@@ -508,5 +520,3 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
-
-dotnet_code_quality.CA1062.null_check_validation_methods = ThrowIfNull|ThrowIfNullOrWhiteSpace

--- a/.editorconfig
+++ b/.editorconfig
@@ -520,3 +520,12 @@ dotnet_diagnostic.SA1651.severity = error
 dotnet_diagnostic.SA1652.severity = none
 dotnet_diagnostic.SX1101.severity = error
 dotnet_diagnostic.SX1309.severity = error
+
+###############################
+# Code Style rules (IDE)      #
+###############################
+
+# See rules here: https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/
+
+# IDE0079: Remove unnecessary suppression
+dotnet_diagnostic.IDE0079.severity = warning

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,10 +35,10 @@ jobs:
       ENVIRONMENT_REPOSITORY_PATH: ${{ secrets.ENVIRONMENT_REPOSITORY_PATH }}
 
   update_coverage_report:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_SQLLOCALDB_2019: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,17 @@ jobs:
 
   database_migration_ci:
     needs: [ci_base, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: databasemigration
-      
+
   dotnet_solution_ci:
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.sln'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       USE_SQLLOCALDB_2019: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -50,21 +50,21 @@ jobs:
       AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
       AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
       AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
-      
+
   organization_func_ci:
     needs: [ci_base, dotnet_solution_ci, terraform_validate]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-function-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/Energinet.DataHub.MarketParticipant.EntryPoint.Organization.csproj'
-      DOTNET_VERSION: '5.0'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: organization
-      
+
   webapi_ci:
     needs: [ci_base, terraform_validate, dotnet_solution_ci]
-    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.0.0
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-create-webapi-artifact.yml@6.1.0
     with:
       CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi.csproj'
-      DOTNET_VERSION: '5.0.404'
+      DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: webapi
 
   create_prerelease:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,18 @@ jobs:
       DOTNET_VERSION: '6.0.201'
       ARTIFACT_NAME: webapi
 
+  package_ci:
+    uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@6.1.0
+    with:
+      SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.Libraries.sln'
+      DOTNET_VERSION: '6.0.201'
+    secrets:
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_SPN_ID: ${{ secrets.AZURE_SPN_ID }}
+      AZURE_SPN_SECRET: ${{ secrets.AZURE_SPN_SECRET }}
+      AZURE_KEYVAULT_URL: ${{ secrets.AZURE_KEYVAULT_URL }}
+
   create_prerelease:
     needs: [
       database_migration_ci,

--- a/.github/workflows/publish-marketparticipant-client.yml
+++ b/.github/workflows/publish-marketparticipant-client.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/Energinet.DataHub.MarketParticipant.Client.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/bin/Release/*.nupkg'
 

--- a/.github/workflows/publish-marketparticipant-model.yml
+++ b/.github/workflows/publish-marketparticipant-model.yml
@@ -32,7 +32,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  DOTNET_VERSION: '5.0'
+  DOTNET_VERSION: '6.0.201'
   CSPROJ_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj'
   BINARY_PATH: 'source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/bin/Release/*.nupkg'
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.0.64">
+        <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.1.46">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -15,7 +15,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
+        <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/build/infrastructure/main/app-webapi.tf
+++ b/build/infrastructure/main/app-webapi.tf
@@ -22,7 +22,7 @@ module "app_webapi" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
-  dotnet_framework_version                  = "v5.0"
+  dotnet_framework_version                  = "v6.0"
 
   app_settings                              = {
     APPINSIGHTS_INSTRUMENTATIONKEY          = "${data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value}"

--- a/build/infrastructure/main/func-organization.tf
+++ b/build/infrastructure/main/func-organization.tf
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 module "func_entrypoint_marketparticipant" {
-  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.4.0"
+  source                                    = "git::https://github.com/Energinet-DataHub/geh-terraform-modules.git//azure/function-app?ref=5.12.0"
 
   name                                      = "organization"
   project_name                              = var.domain_name_short
@@ -22,6 +22,7 @@ module "func_entrypoint_marketparticipant" {
   location                                  = azurerm_resource_group.this.location
   app_service_plan_id                       = data.azurerm_key_vault_secret.plan_shared_id.value
   application_insights_instrumentation_key  = data.azurerm_key_vault_secret.appi_shared_instrumentation_key.value
+  log_analytics_workspace_id                = data.azurerm_key_vault_secret.log_shared_id.value
   always_on                                 = true
   app_settings                              = {
     # Region: Default Values

--- a/build/infrastructure/main/kv-shared-resources.tf
+++ b/build/infrastructure/main/kv-shared-resources.tf
@@ -56,6 +56,10 @@ data "azurerm_key_vault_secret" "plan_shared_id" {
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
 }
 
+data "azurerm_key_vault_secret" "log_shared_id" {
+  name         = "log-shared-id"
+  key_vault_id = data.azurerm_key_vault.kv_shared_resources.id
+}
 data "azurerm_key_vault_secret" "frontend_open_id_url" {
   name         = "frontend-open-id-url"
   key_vault_id = data.azurerm_key_vault.kv_shared_resources.id

--- a/source/Energinet.DataHub.MarketParticipant.Application/Energinet.DataHub.MarketParticipant.Application.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Application/Energinet.DataHub.MarketParticipant.Application.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MarketParticipant.Application/Handlers/Actor/UpdateActorHandler.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Application/Handlers/Actor/UpdateActorHandler.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -51,6 +52,7 @@ namespace Energinet.DataHub.MarketParticipant.Application.Handlers.Actor
             _overlappingBusinessRolesRuleService = overlappingBusinessRolesRuleService;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<Unit> Handle(UpdateActorCommand request, CancellationToken cancellationToken)
         {
             Guard.ThrowIfNull(request, nameof(request));

--- a/source/Energinet.DataHub.MarketParticipant.Application/Handlers/Organization/UpdateOrganizationHandler.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Application/Handlers/Organization/UpdateOrganizationHandler.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Organization;
@@ -44,6 +45,7 @@ namespace Energinet.DataHub.MarketParticipant.Application.Handlers.Organization
             _organizationIntegrationEventsQueueService = organizationIntegrationEventsQueueService;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<Unit> Handle(UpdateOrganizationCommand request, CancellationToken cancellationToken)
         {
             Guard.ThrowIfNull(request, nameof(request));

--- a/source/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp/Energinet.DataHub.MarketParticipant.ApplyDBMigrationsApp.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunAnalyzersDuringBuild>true</RunAnalyzersDuringBuild>

--- a/source/Energinet.DataHub.MarketParticipant.Client/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MarketParticipant.Client/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MarketParticipant.Client Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade
+
 ## Version 0.2.1
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/Energinet.DataHub.MarketParticipant.Client.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/Energinet.DataHub.MarketParticipant.Client.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Energinet.DataHub.MarketParticipant.Client</AssemblyName>

--- a/source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/Energinet.DataHub.MarketParticipant.Client.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Client/source/Energinet.DataHub.MarketParticipant.Client/Energinet.DataHub.MarketParticipant.Client.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MarketParticipant.Client</PackageId>
-    <PackageVersion>0.5.4$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MarketParticipant.Client library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MarketParticipant.Common/Energinet.DataHub.MarketParticipant.Common.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Common/Energinet.DataHub.MarketParticipant.Common.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MarketParticipant.Domain/Energinet.DataHub.MarketParticipant.Domain.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Domain/Energinet.DataHub.MarketParticipant.Domain.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/Energinet.DataHub.MarketParticipant.EntryPoint.Organization.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/Energinet.DataHub.MarketParticipant.EntryPoint.Organization.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,9 +16,9 @@ limitations under the License.
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
-    <AzureFunctionsVersion>V3</AzureFunctionsVersion>
+    <AzureFunctionsVersion>V4</AzureFunctionsVersion>
     <OutputType>Exe</OutputType>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
     <Nullable>enable</Nullable>

--- a/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/HealthCheck/ServiceBusQueueVerifier.cs
+++ b/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/HealthCheck/ServiceBusQueueVerifier.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Azure.Messaging.ServiceBus;
 
@@ -20,6 +21,7 @@ namespace Energinet.DataHub.MarketParticipant.EntryPoint.Organization.HealthChec
 {
     public sealed class ServiceBusQueueVerifier : IServiceBusQueueVerifier
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<bool> VerifyAsync(string connectionString, string name)
         {
             try

--- a/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/HealthCheck/SqlDatabaseVerifier.cs
+++ b/source/Energinet.DataHub.MarketParticipant.EntryPoint.Organization/HealthCheck/SqlDatabaseVerifier.cs
@@ -14,12 +14,14 @@
 
 using System;
 using System.Data.SqlClient;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 
 namespace Energinet.DataHub.MarketParticipant.EntryPoint.Organization.HealthCheck
 {
     public sealed class SqlDatabaseVerifier : ISqlDatabaseVerifier
     {
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<bool> VerifyAsync(string connectionString)
         {
             try

--- a/source/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/source/Energinet.DataHub.MarketParticipant.Infrastructure/Energinet.DataHub.MarketParticipant.Infrastructure.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Infrastructure/Energinet.DataHub.MarketParticipant.Infrastructure.csproj
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MarketParticipant.Infrastructure/Persistence/Repositories/DomainEventRepository.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Infrastructure/Persistence/Repositories/DomainEventRepository.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -41,6 +42,7 @@ namespace Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Reposit
             _domainEventTypesByName = typeof(IIntegrationEvent).Assembly.GetTypes().Where(x => x.IsAssignableTo(typeof(IIntegrationEvent))).ToDictionary(x => x.Name);
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<DomainEventId> InsertAsync(DomainEvent domainEvent)
         {
             Guard.ThrowIfNull(domainEvent, nameof(domainEvent));
@@ -82,6 +84,7 @@ namespace Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Reposit
             await _context.SaveChangesAsync().ConfigureAwait(false);
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<IEnumerable<DomainEvent>> GetOldestUnsentDomainEventsAsync(int numberOfEvents)
         {
             var q = from x in _context.DomainEvents.AsQueryable()

--- a/source/Energinet.DataHub.MarketParticipant.Infrastructure/Services/ActiveDirectoryService.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Infrastructure/Services/ActiveDirectoryService.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Data;
 using System.Data.SqlClient;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Energinet.DataHub.MarketParticipant.Domain.Model;
 using Energinet.DataHub.MarketParticipant.Domain.Services;
@@ -32,6 +33,7 @@ namespace Energinet.DataHub.MarketParticipant.Infrastructure.Services
             _configuration = configuration;
         }
 
+        [SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "Issue: https://github.com/dotnet/roslyn-analyzers/issues/5712")]
         public async Task<ExternalActorId> EnsureAppRegistrationIdAsync(GlobalLocationNumber gln)
         {
             Guard.ThrowIfNull(gln, nameof(gln));

--- a/source/Energinet.DataHub.MarketParticipant.Integration.Model/documents/release-notes/release-notes.md
+++ b/source/Energinet.DataHub.MarketParticipant.Integration.Model/documents/release-notes/release-notes.md
@@ -1,5 +1,9 @@
 # Energinet.DataHub.MarketParticipant.Integration.Model Release notes
 
+## Version 2.0.0
+
+- .NET 6 upgrade
+
 ## Version 1.1.0
 
 - Preparing package for release.

--- a/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>Energinet.DataHub.MarketParticipant.Integration.Model</AssemblyName>
@@ -78,21 +78,21 @@ https://github.com/Energinet-DataHub/geh-market-participant/blob/master/source/E
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net5.0\</OutputDir>
+      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
     <Protobuf Include="Protobuf\GridAreaUpdatedIntegrationEventContract.proto">
       <GrpcServices>None</GrpcServices>
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net5.0\</OutputDir>
+      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
     <Protobuf Include="Protobuf\OrganizationUpdatedIntegrationEventContract.proto">
       <GrpcServices>None</GrpcServices>
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net5.0\</OutputDir>
+      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
@@ -78,21 +78,18 @@ https://github.com/Energinet-DataHub/geh-market-participant/blob/master/source/E
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
     <Protobuf Include="Protobuf\GridAreaUpdatedIntegrationEventContract.proto">
       <GrpcServices>None</GrpcServices>
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
     <Protobuf Include="Protobuf\OrganizationUpdatedIntegrationEventContract.proto">
       <GrpcServices>None</GrpcServices>
       <Access>Internal</Access>
       <ProtoCompile>True</ProtoCompile>
       <CompileOutputs>True</CompileOutputs>
-      <OutputDir>obj\Debug\net6.0\</OutputDir>
     </Protobuf>
   </ItemGroup>
 

--- a/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Integration.Model/source/Energinet.DataHub.MarketParticipant.Integration.Model/Energinet.DataHub.MarketParticipant.Integration.Model.csproj
@@ -27,7 +27,7 @@ limitations under the License.
 
   <PropertyGroup>
     <PackageId>Energinet.DataHub.MarketParticipant.Integration.Model</PackageId>
-    <PackageVersion>1.2.0$(VersionSuffix)</PackageVersion>
+    <PackageVersion>2.0.0$(VersionSuffix)</PackageVersion>
     <Title>Energinet.DataHub.MarketParticipant.Integration.Model library</Title>
     <Company>Energinet-DataHub</Company>
     <Authors>Energinet-DataHub</Authors>

--- a/source/Energinet.DataHub.MarketParticipant.IntegrationTests/.editorconfig
+++ b/source/Energinet.DataHub.MarketParticipant.IntegrationTests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/source/Energinet.DataHub.MarketParticipant.Libraries.Tests/Clients/MarketParticipantClientTests.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Libraries.Tests/Clients/MarketParticipantClientTests.cs
@@ -49,7 +49,7 @@ namespace Energinet.DataHub.MarketParticipant.Libraries.Tests.Clients
 
             // Act + Assert
             var exception = await Assert
-                .ThrowsAsync<FlurlHttpException>(() => target.GetOrganizationsAsync())
+                .ThrowsAsync<MarketParticipantException>(() => target.GetOrganizationsAsync())
                 .ConfigureAwait(false);
             Assert.Equal(exception.StatusCode, (int)HttpStatusCode.Unauthorized);
         }

--- a/source/Energinet.DataHub.MarketParticipant.Libraries.Tests/Energinet.DataHub.MarketParticipant.Libraries.Tests.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Libraries.Tests/Energinet.DataHub.MarketParticipant.Libraries.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -16,7 +16,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/source/Energinet.DataHub.MarketParticipant.Tests/.editorconfig
+++ b/source/Energinet.DataHub.MarketParticipant.Tests/.editorconfig
@@ -1,0 +1,24 @@
+# Copyright 2020 Energinet DataHub A/S
+#
+# Licensed under the Apache License, Version 2.0 (the "License2");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+[*.cs]
+
+###############################
+# .NET Analyzers              #
+###############################
+
+# Set as suggestion at the moment, because of issue: https://github.com/dotnet/roslyn-analyzers/issues/5712
+dotnet_diagnostic.CA2007.severity = suggestion

--- a/source/Energinet.DataHub.MarketParticipant.Tests/Energinet.DataHub.MarketParticipant.Tests.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Tests/Energinet.DataHub.MarketParticipant.Tests.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/Energinet.DataHub.MarketParticipant.Utilities/Energinet.DataHub.MarketParticipant.Utilities.csproj
+++ b/source/Energinet.DataHub.MarketParticipant.Utilities/Energinet.DataHub.MarketParticipant.Utilities.csproj
@@ -1,4 +1,4 @@
-<!--
+﻿<!--
 Copyright 2020 Energinet DataHub A/S
 
 Licensed under the Apache License, Version 2.0 (the "License2");
@@ -17,7 +17,7 @@ limitations under the License.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
## Description

Upgrade Market Participant to .NET 6 and function v4.

Important:
* Focus is on upgrading to .NET 6 and functions v4. Only NuGet packages directly impacted by this (meaning Analyzers) has been updated.
* NuGet packages build within the domain has also been updated to .NET 6 and all version numbers bumped to the next major version to signal the "breaking change". It means that any domain that want to use these packages in the future, must update their domain to .NET 6 (which is what we want anyway).

## References

https://app.zenhub.com/workspaces/mighty-ducks---the-outlaws-6193fe815d79fc0011e741b1/issues/energinet-datahub/the-outlaws/258
