### PR TITLE
Remove DOTNET_VERSION from ci+cd.yml

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,7 +38,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_SQLLOCALDB_2019: true
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.sln'
-      DOTNET_VERSION: '6.0.301'
       USE_SQLLOCALDB_2019: true
       PREPARE_OUTPUTS: true
     secrets:
@@ -50,7 +49,6 @@ jobs:
     uses: Energinet-DataHub/.github/.github/workflows/dotnet-solution-ci.yml@7.7.0
     with:
       SOLUTION_FILE_PATH: 'source/Energinet.DataHub.MarketParticipant.Libraries.sln'
-      DOTNET_VERSION: '6.0.301'
     secrets:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
Speed up CI execution time by using default .NET Core SDK version pre-installed on hosted Github Runner

Reference: https://github.com/Energinet-DataHub/the-outlaws/issues/360