### PR TITLE
added create-latest-release to cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,12 +20,20 @@ on:
 
 jobs:
   publish_release:
-    uses: Energinet-DataHub/.github/.github/workflows/publish-release.yml@v8
-    secrets:
-      PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+    uses: Energinet-DataHub/.github/.github/workflows/promote-prerelease.yml@v8
+    with:
+      RELEASE_NAME_PREFIX: dotnet
+
+  create_latest_release:
+    uses: Energinet-DataHub/.github/.github/workflows/create-latest-release.yml@v8
+    with:
+      RELEASE_NAME_PREFIX: dotnet
 
   dispatch_deployment_request:
-    needs: publish_release
+    needs: [
+      publish_release,
+      create_latest_release
+    ]
     uses: Energinet-DataHub/.github/.github/workflows/dispatch-deployment-request.yml@v8
     with:
       CALLER_REPOSITORY_NAME: geh-market-participant


### PR DESCRIPTION
<!--- 🙏 Thank you for your submission, we really appreciate it. Like many open source projects, we ask that you sign our [Contributor License Agreement](https://cla-assistant.io/Energinet-DataHub/geh-metering-point) before we can accept your contribution. --->

## Description

<!--- Please leave a helpful description of the pull request here. --->
As a part of our new rollout strategy, we want to be able to always have an up to date `dotnet_latest` version besides the running version.
This is to support the possibility to find the latest release by the tag name `dotnet_latest`

This is an addition to the CD job, it will only create and maintain a new `dotnet_latest` release.

BE AWARE that we will do another iteration splitting infrastructure away from the dotnet package, so this is only to introduce a non breaking rollout