### PR TITLE
fix: Return null when user does not exist in AD.

### DIFF
--- a/source/Energinet.DataHub.MarketParticipant.Application/Handlers/GridArea/GetGridAreaAuditLogEntriesHandler.cs
+++ b/source/Energinet.DataHub.MarketParticipant.Application/Handlers/GridArea/GetGridAreaAuditLogEntriesHandler.cs
@@ -64,15 +64,7 @@ namespace Energinet.DataHub.MarketParticipant.Application.Handlers.GridArea
                             .GetAsync(user.ExternalId)
                             .ConfigureAwait(false);
 
-                        // TODO: Correct error message?
-                        if (userIdentity == null)
-                        {
-                            userName = "[NOT FOUND IN AD]";
-                        }
-                        else
-                        {
-                            userName = userIdentity.FullName;
-                        }
+                        userName = userIdentity?.FullName;
                     }
 
                     userNameLookup[entry.UserId] = userName;


### PR DESCRIPTION
API already supports returning NULL as DisplayName when user is missing. No need to handle case.