### PR TITLE
Do not return expired keys from keys-endpoint.

### DIFF
--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Security/SigningKeyRing.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Security/SigningKeyRing.cs
@@ -88,9 +88,16 @@ public sealed class SigningKeyRing : ISigningKeyRing
         var keyVersions = _keyClient.GetPropertiesOfKeyVersionsAsync(_keyName);
         var keys = new List<KeyVaultKey>();
 
+        var currentTime = _clock
+            .GetCurrentInstant()
+            .ToDateTimeOffset();
+
         await foreach (var keyDescription in keyVersions)
         {
             if (keyDescription.Enabled != true)
+                continue;
+
+            if (keyDescription.ExpiresOn < currentTime)
                 continue;
 
             var keyVersion = await _keyClient

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Security/SigningKeyRingIntegrationTests.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Security/SigningKeyRingIntegrationTests.cs
@@ -105,7 +105,7 @@ public sealed class SigningKeyRingIntegrationTests : IClassFixture<KeyClientFixt
     }
 
     [Fact]
-    public async Task GetKeysAsync_WithExpiredKey_ReturnsKey()
+    public async Task GetKeysAsync_WithExpiredKey_ReturnsNothing()
     {
         // Arrange
         var target = new SigningKeyRing(
@@ -125,7 +125,7 @@ public sealed class SigningKeyRingIntegrationTests : IClassFixture<KeyClientFixt
         var keys = await target.GetKeysAsync();
 
         // Assert
-        Assert.Single(keys);
+        Assert.Empty(keys);
 
         // Cleanup
         await _keyClientFixture


### PR DESCRIPTION
We no longer return expired keys from /token/keys endpoint. This is done to keep the list of keys tidy, as we can never sign with an expired key anyway and the rotation happens a couple of days before expiration.

One difference is though that if we rotate a key manually, the existing tokens all become invalid. This was not the original indended behaviour, but opinions changed and the test was updated to reflect this.