### PR TITLE
Share Azure Credentials across tests

### DIFF
--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsHelper.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsHelper.cs
@@ -16,7 +16,7 @@ using Azure.Identity;
 
 namespace Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 
-internal class AzureCredentialsHelper
+internal static class AzureCredentialsHelper
 {
     public static DefaultAzureCredential Credentials { get; } = new DefaultAzureCredential();
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsHelper.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsHelper.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Azure.Identity;
+
+namespace Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
+
+internal class AzureCredentialsHelper
+{
+    public static DefaultAzureCredential Credentials { get; } = new DefaultAzureCredential();
+}

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsProvider.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Common/AzureCredentialsProvider.cs
@@ -16,7 +16,7 @@ using Azure.Identity;
 
 namespace Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 
-internal static class AzureCredentialsHelper
+internal static class AzureCredentialsProvider
 {
     public static DefaultAzureCredential Credentials { get; } = new DefaultAzureCredential();
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
@@ -22,7 +22,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.1.1" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.2.1-alpha-360" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.7.1" />

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Energinet.DataHub.MarketParticipant.IntegrationTests.csproj
@@ -22,7 +22,7 @@ limitations under the License.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.2.1-alpha-360" />
+    <PackageReference Include="Energinet.DataHub.Core.FunctionApp.TestCommon" Version="5.2.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.7.1" />

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/ActorClientSecretFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/ActorClientSecretFixture.cs
@@ -32,7 +32,7 @@ public sealed class ActorClientSecretFixture : IAsyncLifetime
 
     public Task InitializeAsync()
     {
-        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsHelper.Credentials);
+        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsProvider.Credentials);
 
         _graphClient = new GraphServiceClient(
             new ClientSecretCredential(

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/ActorClientSecretFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/ActorClientSecretFixture.cs
@@ -17,6 +17,7 @@ using Azure.Identity;
 using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.MarketParticipant.Domain.Services;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
+using Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 using Microsoft.Graph;
 using Xunit;
 
@@ -31,7 +32,7 @@ public sealed class ActorClientSecretFixture : IAsyncLifetime
 
     public Task InitializeAsync()
     {
-        var integrationTestConfig = new IntegrationTestConfiguration();
+        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsHelper.Credentials);
 
         _graphClient = new GraphServiceClient(
             new ClientSecretCredential(

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/B2CFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/B2CFixture.cs
@@ -18,6 +18,7 @@ using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.MarketParticipant.Domain.Services;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Options;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
+using Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 using Microsoft.Extensions.Options;
 using Microsoft.Graph;
 using Xunit;
@@ -33,7 +34,7 @@ public sealed class B2CFixture : IAsyncLifetime
 
     public Task InitializeAsync()
     {
-        var integrationTestConfig = new IntegrationTestConfiguration();
+        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsHelper.Credentials);
 
         // Graph Service Client
         var clientSecretCredential = new ClientSecretCredential(

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/B2CFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/B2CFixture.cs
@@ -34,7 +34,7 @@ public sealed class B2CFixture : IAsyncLifetime
 
     public Task InitializeAsync()
     {
-        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsHelper.Credentials);
+        var integrationTestConfig = new IntegrationTestConfiguration(AzureCredentialsProvider.Credentials);
 
         // Graph Service Client
         var clientSecretCredential = new ClientSecretCredential(

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/CertificateFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/CertificateFixture.cs
@@ -21,6 +21,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Secrets;
 using Energinet.DataHub.Core.FunctionApp.TestCommon;
 using Energinet.DataHub.MarketParticipant.Application.Services;
+using Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -36,7 +37,7 @@ public sealed class CertificateFixture : IAsyncLifetime
     public Task InitializeAsync()
     {
         var keyVaultUri = GetKeyVaultUri();
-        SecretClient = new SecretClient(keyVaultUri, new DefaultAzureCredential());
+        SecretClient = new SecretClient(keyVaultUri, AzureCredentialsHelper.Credentials);
 
         var certValidation = new Mock<ICertificateValidation>();
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/CertificateFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/CertificateFixture.cs
@@ -37,7 +37,7 @@ public sealed class CertificateFixture : IAsyncLifetime
     public Task InitializeAsync()
     {
         var keyVaultUri = GetKeyVaultUri();
-        SecretClient = new SecretClient(keyVaultUri, AzureCredentialsHelper.Credentials);
+        SecretClient = new SecretClient(keyVaultUri, AzureCredentialsProvider.Credentials);
 
         var certValidation = new Mock<ICertificateValidation>();
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/GraphServiceClientFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/GraphServiceClientFixture.cs
@@ -34,7 +34,7 @@ namespace Energinet.DataHub.MarketParticipant.IntegrationTests.Fixtures;
 public sealed class GraphServiceClientFixture : IAsyncLifetime
 #pragma warning restore CA1001
 {
-    private readonly IntegrationTestConfiguration _integrationTestConfiguration = new(AzureCredentialsHelper.Credentials);
+    private readonly IntegrationTestConfiguration _integrationTestConfiguration = new(AzureCredentialsProvider.Credentials);
     private readonly List<ExternalUserId> _createdUsers = new();
     private GraphServiceClient? _graphClient;
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/GraphServiceClientFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/GraphServiceClientFixture.cs
@@ -21,6 +21,7 @@ using Energinet.DataHub.Core.FunctionApp.TestCommon.Configuration;
 using Energinet.DataHub.MarketParticipant.Domain.Model.ActiveDirectory;
 using Energinet.DataHub.MarketParticipant.Domain.Model.Users;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Extensions;
+using Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 using Microsoft.Graph;
 using Microsoft.Graph.Models;
 using Microsoft.Graph.Models.ODataErrors;
@@ -33,7 +34,7 @@ namespace Energinet.DataHub.MarketParticipant.IntegrationTests.Fixtures;
 public sealed class GraphServiceClientFixture : IAsyncLifetime
 #pragma warning restore CA1001
 {
-    private readonly IntegrationTestConfiguration _integrationTestConfiguration = new();
+    private readonly IntegrationTestConfiguration _integrationTestConfiguration = new(AzureCredentialsHelper.Credentials);
     private readonly List<ExternalUserId> _createdUsers = new();
     private GraphServiceClient? _graphClient;
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/KeyClientFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/KeyClientFixture.cs
@@ -17,6 +17,7 @@ using System.Threading.Tasks;
 using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Energinet.DataHub.Core.FunctionApp.TestCommon;
+using Energinet.DataHub.MarketParticipant.IntegrationTests.Common;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 
@@ -31,7 +32,7 @@ public sealed class KeyClientFixture : IAsyncLifetime
     public Task InitializeAsync()
     {
         var keyVaultUri = GetKeyVaultUri();
-        KeyClient = new KeyClient(keyVaultUri, new DefaultAzureCredential());
+        KeyClient = new KeyClient(keyVaultUri, AzureCredentialsHelper.Credentials);
 
         var rsaKeyOptions = CreateTestKeyOptions();
         return KeyClient.CreateRsaKeyAsync(rsaKeyOptions);

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/KeyClientFixture.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.IntegrationTests/Fixtures/KeyClientFixture.cs
@@ -32,7 +32,7 @@ public sealed class KeyClientFixture : IAsyncLifetime
     public Task InitializeAsync()
     {
         var keyVaultUri = GetKeyVaultUri();
-        KeyClient = new KeyClient(keyVaultUri, AzureCredentialsHelper.Credentials);
+        KeyClient = new KeyClient(keyVaultUri, AzureCredentialsProvider.Credentials);
 
         var rsaKeyOptions = CreateTestKeyOptions();
         return KeyClient.CreateRsaKeyAsync(rsaKeyOptions);


### PR DESCRIPTION
## Description
Reuse the same `DefaultAzureCredentials`, to improve the time it takes to read the keyvault

## References
