### PR TITLE
Cleanup: Change Actor.MarketRoles property from a collection to a single element: MarketRole

### DIFF
--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Commands/Actors/ActorDto.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Commands/Actors/ActorDto.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
 
 namespace Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
 
@@ -23,4 +22,4 @@ public sealed record ActorDto(
     string Status,
     ActorNumberDto ActorNumber,
     ActorNameDto Name,
-    IEnumerable<ActorMarketRoleDto> MarketRoles);
+    ActorMarketRoleDto MarketRole);

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Commands/Actors/ActorMarketRoleDto.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Commands/Actors/ActorMarketRoleDto.cs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Collections.Generic;
 using Energinet.DataHub.MarketParticipant.Domain.Model;
 
 namespace Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
 
-public sealed record ActorMarketRoleDto(EicFunction EicFunction, IEnumerable<ActorGridAreaDto> GridAreas, string? Comment);
+public sealed record ActorMarketRoleDto(EicFunction EicFunction, string? Comment);

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Handlers/CreateActorHandler.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Handlers/CreateActorHandler.cs
@@ -1,0 +1,47 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
+using Energinet.DataHub.MarketParticipant.Domain.Model;
+using Energinet.DataHub.MarketParticipant.Domain.Repositories;
+using MediatR;
+
+namespace Energinet.DataHub.MarketParticipant.Application.Handlers;
+
+public sealed class CreateActorHandler : IRequestHandler<CreateActorCommand, CreateActorResponse>
+{
+    private readonly IActorRepository _actorRepository;
+
+    public CreateActorHandler(IActorRepository actorRepository)
+    {
+        _actorRepository = actorRepository;
+    }
+
+    public async Task<CreateActorResponse> Handle(CreateActorCommand request, CancellationToken cancellationToken)
+    {
+        var actor = new Actor(
+            new OrganizationId(request.OrganizationId),
+            new ActorNumber(request.ActorNumber.Value),
+            new ActorName(request.Name.Value))
+        {
+            MarketRole = new ActorMarketRole(request.MarketRole.EicFunction, request.MarketRole.Comment)
+        };
+
+        await _actorRepository.AddOrUpdateAsync(actor).ConfigureAwait(false);
+
+        return new CreateActorResponse(actor.Id.Value);
+    }
+}

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Handlers/UpdateActorHandler.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Application/Handlers/UpdateActorHandler.cs
@@ -1,0 +1,49 @@
+﻿// Copyright 2020 Energinet DataHub A/S
+//
+// Licensed under the Apache License, Version 2.0 (the "License2");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
+using Energinet.DataHub.MarketParticipant.Domain.Model;
+using Energinet.DataHub.MarketParticipant.Domain.Repositories;
+using MediatR;
+
+namespace Energinet.DataHub.MarketParticipant.Application.Handlers;
+
+public sealed class UpdateActorHandler : IRequestHandler<UpdateActorCommand>
+{
+    private readonly IActorRepository _actorRepository;
+
+    public UpdateActorHandler(IActorRepository actorRepository)
+    {
+        _actorRepository = actorRepository;
+    }
+
+    public async Task<Unit> Handle(UpdateActorCommand request, CancellationToken cancellationToken)
+    {
+        var actor = await _actorRepository.GetAsync(new ActorId(request.ActorId)).ConfigureAwait(false);
+
+        if (actor == null)
+        {
+            throw new NotFoundException($"Actor with id {request.ActorId} not found.");
+        }
+
+        actor.Name = new ActorName(request.Name.Value);
+        actor.MarketRole = new ActorMarketRole(request.MarketRole.EicFunction, request.MarketRole.Comment);
+
+        await _actorRepository.AddOrUpdateAsync(actor).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Domain/Model/ActorMarketRole.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Domain/Model/ActorMarketRole.cs
@@ -13,31 +13,22 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Energinet.DataHub.MarketParticipant.Domain.Model;
 
 public sealed class ActorMarketRole
 {
-    public ActorMarketRole(EicFunction eic, IEnumerable<ActorGridArea> gridAreas, string? comment)
+    public ActorMarketRole(EicFunction eic, string? comment)
     {
-        GridAreas = gridAreas.ToList();
         Function = eic;
         Comment = comment;
     }
 
-    public ActorMarketRole(EicFunction eic, IEnumerable<ActorGridArea> gridAreas)
-        : this(eic, gridAreas, null)
-    {
-    }
-
     public ActorMarketRole(EicFunction eic)
-        : this(eic, Array.Empty<ActorGridArea>(), null)
+        : this(eic, null)
     {
     }
 
-    public IReadOnlyCollection<ActorGridArea> GridAreas { get; }
     public EicFunction Function { get; }
     public string? Comment { get; }
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Tests/Handlers/UpdateActorHandlerTests.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Tests/Handlers/UpdateActorHandlerTests.cs
@@ -51,7 +51,7 @@ public sealed class UpdateActorHandlerTests
 
         var command = new UpdateActorCommand(
             actorId,
-            new ChangeActorDto("Active", new ActorNameDto(string.Empty), Array.Empty<ActorMarketRoleDto>()));
+            new ChangeActorDto("Active", new ActorNameDto(string.Empty), new ActorMarketRoleDto(EicFunction.BalanceResponsibleParty, null)));
 
         // Act + Assert
         await Assert.ThrowsAsync<NotFoundValidationException>(() => target.Handle(command, CancellationToken.None));
@@ -74,7 +74,7 @@ public sealed class UpdateActorHandlerTests
 
         var command = new UpdateActorCommand(
             actor.Id.Value,
-            new ChangeActorDto("Active", new ActorNameDto(string.Empty), Array.Empty<ActorMarketRoleDto>()));
+            new ChangeActorDto("Active", new ActorNameDto(string.Empty), new ActorMarketRoleDto(EicFunction.BalanceResponsibleParty, null)));
 
         // Act
         await target.Handle(command, CancellationToken.None);
@@ -103,7 +103,7 @@ public sealed class UpdateActorHandlerTests
 
         var command = new UpdateActorCommand(
             actor.Id.Value,
-            new ChangeActorDto("Active", new ActorNameDto(string.Empty), Array.Empty<ActorMarketRoleDto>()));
+            new ChangeActorDto("Active", new ActorNameDto(string.Empty), new ActorMarketRoleDto(EicFunction.BalanceResponsibleParty, null)));
 
         // Act
         await target.Handle(command, CancellationToken.None);


### PR DESCRIPTION
Change the `MarketRoles` property from a collection to a single element `MarketRole` in the `Actor` class.

* **Domain Model Changes**
  - Modify `Actor.cs` to change `MarketRoles` property to a single `MarketRole`.
  - Update the constructor to accept a single `ActorMarketRole` instead of an `IEnumerable<ActorMarketRole>`.
  - Update the `AddMarketRole` and `RemoveMarketRole` methods to handle a single `ActorMarketRole`.
  - Update the `Activate` method to handle a single `ActorMarketRole`.
  - Update the `Credentials` property to handle a single `ActorMarketRole`.
  - Modify `ActorMarketRole.cs` to remove the `GridAreas` property and update the constructor accordingly.

* **Application Layer Changes**
  - Modify `ActorDto.cs` to change `MarketRoles` property to a single `ActorMarketRoleDto`.
  - Modify `ActorMarketRoleDto.cs` to remove the `GridAreas` property and update the constructor accordingly.
  - Add `CreateActorHandler.cs` to handle a single `ActorMarketRole` instead of an `IEnumerable<ActorMarketRole>`.
  - Add `UpdateActorHandler.cs` to handle a single `ActorMarketRole` instead of an `IEnumerable<ActorMarketRole>`.

* **Test Changes**
  - Modify `CreateActorHandlerTests.cs` to handle a single `ActorMarketRole` instead of an `IEnumerable<ActorMarketRole>`.
  - Modify `UpdateActorHandlerTests.cs` to handle a single `ActorMarketRole` instead of an `IEnumerable<ActorMarketRole>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Energinet-DataHub/geh-market-participant?shareId=14ff1482-06aa-497a-af4e-544e624de423).