### PR TITLE
Remove duplicates in actor consolidation audit log

### DIFF
--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Infrastructure/Persistence/Repositories/ActorConsolidationAuditLogRepository.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Infrastructure/Persistence/Repositories/ActorConsolidationAuditLogRepository.cs
@@ -76,8 +76,11 @@ public sealed class ActorConsolidationAuditLogRepository : IActorConsolidationAu
             .ToListAsync()
             .ConfigureAwait(false);
 
+        var distinctEntities = entities
+            .DistinctBy(log => new { log.OldValue, log.NewValue });
+
         return
-            from entity in entities
+            from entity in distinctEntities
             let change = Map((ActorConsolidationAuditLogField)entity.Field)
             select new AuditLog<ActorAuditedChange>(
                 change,


### PR DESCRIPTION
The duplicates were because the `ActorConsolidationAuditLogEntry` table has a `GridAreaId` column, so if the actor has multiple grid areas, it will have an entry there per grid area