### PR TITLE
Create and verify signature now uses key from Azure key vault

### DIFF
--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Energinet.DataHub.MarketParticipant.Authorization.csproj
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Energinet.DataHub.MarketParticipant.Authorization.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.13.2" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.7.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\Energinet.DataHub.MarketParticipant.Domain\Energinet.DataHub.MarketParticipant.Domain.csproj" />
   </ItemGroup>
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Services/AuthorizationService.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Services/AuthorizationService.cs
@@ -44,8 +44,8 @@ namespace Energinet.DataHub.MarketParticipant.Authorization.Services
             // Create signature should always simply use the current version.
             // Verify should use the version it gets from a input parameter.
             // Currently it just load once the current version from the key vault.
-            //_key.Properties.Version
-            //_cryptoClient = _keyClient.GetCryptographyClient(_keyName, "KeyVersion");
+            // _key.Properties.Version
+            // _cryptoClient = _keyClient.GetCryptographyClient(_keyName, "KeyVersion");
             _cryptoClient = new CryptographyClient(_key.Id, new DefaultAzureCredential());
         }
 
@@ -57,7 +57,6 @@ namespace Energinet.DataHub.MarketParticipant.Authorization.Services
             // For now just return a static signature
             // Will be later something like this:
             // Var binaryRestriction = restriction.ToByteArray();
-            var keyVersion = _key.Properties.Version;
             byte[] binaryRestriction = [1, 2, 3, 4];
             var signature = await _cryptoClient.SignDataAsync(SignatureAlgorithm.RS256, binaryRestriction).ConfigureAwait(false);
             return new RestrictionSignatureDto(Convert.ToBase64String(signature.Signature));

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Services/AuthorizationService.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Authorization/Services/AuthorizationService.cs
@@ -12,23 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Net;
 using System.Security.Cryptography;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
 using Energinet.DataHub.MarketParticipant.Authorization.Restriction;
+using static NodaTime.TimeZones.ZoneEqualityComparer;
 
 namespace Energinet.DataHub.MarketParticipant.Authorization.Services
 {
     public sealed class AuthorizationService : IAuthorizationService
     {
-        private readonly ECDsa _ecdsa = ECDsa.Create();
+        private readonly KeyClient _keyClient;
+        private readonly Uri _keyVault;
+        private readonly string _keyName;
+        private readonly KeyVaultKey _key;
+        private readonly CryptographyClient _cryptoClient;
 
-        public AuthorizationService()
+        public AuthorizationService(Uri keyVault, string keyName)
         {
-        }
+            _keyVault = keyVault;
+            _keyName = keyName;
+            _keyClient = new KeyClient(keyVault, new DefaultAzureCredential());
+            _key = _keyClient.GetKey(_keyName);
 
-        // Copied from example. Not sure when it is called.
-        public void Dispose()
-        {
-            _ecdsa.Dispose();
+            // Todo:
+            // Because of keyRotation, multiple versions of the key can be in use.
+            // The versions used should be stored in an array or something like that and updated overtime.
+            // Create signature should always simply use the current version.
+            // Verify should use the version it gets from a input parameter.
+            // Currently it just load once the current version from the key vault.
+            //_key.Properties.Version
+            //_cryptoClient = _keyClient.GetCryptographyClient(_keyName, "KeyVersion");
+            _cryptoClient = new CryptographyClient(_key.Id, new DefaultAzureCredential());
         }
 
         // Later this task has AuthorizationRestriction and UserIdentification as input
@@ -39,10 +57,10 @@ namespace Energinet.DataHub.MarketParticipant.Authorization.Services
             // For now just return a static signature
             // Will be later something like this:
             // Var binaryRestriction = restriction.ToByteArray();
+            var keyVersion = _key.Properties.Version;
             byte[] binaryRestriction = [1, 2, 3, 4];
-            var signature = _ecdsa.SignData(binaryRestriction, HashAlgorithmName.SHA256);
-
-            return new RestrictionSignatureDto(Convert.ToBase64String(signature));
+            var signature = await _cryptoClient.SignDataAsync(SignatureAlgorithm.RS256, binaryRestriction).ConfigureAwait(false);
+            return new RestrictionSignatureDto(Convert.ToBase64String(signature.Signature));
         }
 
         public async Task<bool> VerifySignatureAsync(AuthorizationRestriction restriction, string signature)
@@ -51,10 +69,9 @@ namespace Energinet.DataHub.MarketParticipant.Authorization.Services
             // Var binaryRestriction = restriction.ToByteArray();
             // For now Static
             byte[] binaryRestriction = [1, 2, 3, 4];
-
             var conversionResult = Convert.FromBase64String(signature);
-
-            return _ecdsa.VerifyData(binaryRestriction, conversionResult, HashAlgorithmName.SHA256);
+            var verifyResult = await _cryptoClient.VerifyDataAsync(SignatureAlgorithm.RS256, binaryRestriction, conversionResult).ConfigureAwait(false);
+            return verifyResult.IsValid;
         }
     }
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Energinet.DataHub.MarketParticipant.Application.Commands;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
@@ -31,13 +30,11 @@ using Energinet.DataHub.MarketParticipant.Application.Commands.Users;
 using Energinet.DataHub.MarketParticipant.Application.Handlers.Integration;
 using Energinet.DataHub.MarketParticipant.Application.Services;
 using Energinet.DataHub.MarketParticipant.Application.Validation;
-using Energinet.DataHub.MarketParticipant.Authorization.Services;
 using Energinet.DataHub.MarketParticipant.Domain.Services;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Repositories;
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Options;
 using NodaTime;
 
 namespace Energinet.DataHub.MarketParticipant.Common;

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Azure.Security.KeyVault.Keys;
 using Energinet.DataHub.MarketParticipant.Application.Commands;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Authorization;
@@ -35,7 +34,6 @@ using Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Repositorie
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
-using NodaTime;
 
 namespace Energinet.DataHub.MarketParticipant.Common;
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
@@ -34,7 +34,6 @@ using Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Repositorie
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
-using NodaTime;
 
 namespace Energinet.DataHub.MarketParticipant.Common;
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
@@ -34,6 +34,7 @@ using Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Repositorie
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using NodaTime;
 
 namespace Energinet.DataHub.MarketParticipant.Common;
 

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.Common/ApplicationServiceRegistration.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using Azure.Identity;
+using Azure.Security.KeyVault.Keys;
 using Energinet.DataHub.MarketParticipant.Application.Commands;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Actors;
 using Energinet.DataHub.MarketParticipant.Application.Commands.Authorization;
@@ -35,6 +37,8 @@ using Energinet.DataHub.MarketParticipant.Infrastructure.Persistence.Repositorie
 using Energinet.DataHub.MarketParticipant.Infrastructure.Services;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NodaTime;
 
 namespace Energinet.DataHub.MarketParticipant.Common;
 
@@ -136,6 +140,6 @@ internal static class ApplicationServiceRegistration
         services.AddScoped<IActorCredentialsRemovalService, ActorCredentialsRemovalService>();
 
         // services.AddScoped<IAuthorizationService, AuthorizationService>();
-        services.AddSingleton<IAuthorizationService, AuthorizationService>();
+        // services.AddSingleton<IAuthorizationService, AuthorizationService>();
     }
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/MarketParticipantWebApiModuleExtensions.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/MarketParticipantWebApiModuleExtensions.cs
@@ -16,6 +16,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Secrets;
 using Energinet.DataHub.MarketParticipant.Application.Services;
+using Energinet.DataHub.MarketParticipant.Authorization.Services;
 using Energinet.DataHub.MarketParticipant.Common;
 using Energinet.DataHub.MarketParticipant.Common.Options;
 using Energinet.DataHub.MarketParticipant.EntryPoint.WebApi.Options;
@@ -58,6 +59,14 @@ public static class MarketParticipantWebApiModuleExtensions
             var clock = provider.GetRequiredService<IClock>();
             var keyClient = new KeyClient(options.Value.TokenSignKeyVault, tokenCredentials);
             return new SigningKeyRing(clock, keyClient, options.Value.TokenSignKeyName);
+        });
+
+        _ = services.AddSingleton<IAuthorizationService>(provider =>
+        {
+            var tokenCredentials = new DefaultAzureCredential();
+            var options = provider.GetRequiredService<IOptions<KeyVaultOptions>>();
+            var keyClient = new KeyClient(options.Value.TokenSignKeyVault, tokenCredentials);
+            return new AuthorizationService(options.Value.TokenSignKeyVault, options.Value.AuthSignKeyName);
         });
 
         services.AddSingleton(provider =>

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Options/KeyVaultOptions.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Options/KeyVaultOptions.cs
@@ -29,4 +29,7 @@ public sealed record KeyVaultOptions
 
     [Required]
     public Uri CertificatesKeyVault { get; set; } = null!;
+
+    [Required]
+    public string AuthSignKeyName { get; set; } = null!;
 }

--- a/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Options/KeyVaultOptions.cs
+++ b/source/marketparticipant/Energinet.DataHub.MarketParticipant.EntryPoint.WebApi/Options/KeyVaultOptions.cs
@@ -30,6 +30,5 @@ public sealed record KeyVaultOptions
     [Required]
     public Uri CertificatesKeyVault { get; set; } = null!;
 
-    [Required]
     public string AuthSignKeyName { get; set; } = null!;
 }


### PR DESCRIPTION
Create and verify signature now uses key from Azure key vault.

The following should be added to appsettings.json to make sure it can run against the dwe002 environment:
"KeyVault:AuthSignKeyName": "token-sign",

Currently it uses the existing key "token-sign". Later when the new key exists this should be: "authorization-signature" 
Key rotation settings in Azure should still be discussed.
For use and implement key rotations in the code, I've added some comments in the code of the Authorization service as an idea.